### PR TITLE
Fix ActionController::Parameters#require sigs

### DIFF
--- a/rbi/annotations/actionpack.rbi
+++ b/rbi/annotations/actionpack.rbi
@@ -111,13 +111,13 @@ class ActionController::Parameters
   sig { params(key: T.any(String, Symbol)).returns(T.untyped) }
   def [](key); end
 
-  sig { params(key: T.any(String, Symbol)).returns(ActionController::Parameters) }
-  sig { params(key: T::Array[T.any(String, Symbol)]).returns(T::Array[ActionController::Parameters]) }
+  sig { params(key: T.any(String, Symbol)).returns(T.untyped) }
+  sig { params(key: T::Array[T.any(String, Symbol)]).returns(T::Array[T.untyped]) }
   def require(key); end
 
   # required is an alias of require
-  sig { params(key: T.any(String, Symbol)).returns(ActionController::Parameters) }
-  sig { params(key: T::Array[T.any(String, Symbol)]).returns(T::Array[ActionController::Parameters]) }
+  sig { params(key: T.any(String, Symbol)).returns(T.untyped) }
+  sig { params(key: T::Array[T.any(String, Symbol)]).returns(T::Array[T.untyped]) }
   def required(key); end
 
   sig { params(other_hash: T.untyped).returns(ActionController::Parameters) }


### PR DESCRIPTION
as raised in #231. This is often a scalar, rather than nested parameters, but it can be anything.

### Type of Change

- [ ] Add RBI for a new gem
- [x] Modify RBI for an existing gem
- [ ] Other: <!-- Provide additional information -->

### Changes

* Gem name: actionpack
* Gem version: at least >= 6
* Gem source: https://github.com/rails/rails/blob/3235827585d87661942c91bc81f64f56d710f0b2/actionpack/lib/action_controller/metal/strong_parameters.rb#L519
* Gem API doc: https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-require
* Tapioca version: 0.16.2
* Sorbet version: 0.5.11139
